### PR TITLE
Fix wallet derivation and expose public keys for multi-wallet ops

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -198,6 +198,7 @@ async function getWalletStatus(walletInfo: any, chains: string[]) {
     address: walletInfo.address,
     index: walletInfo.index,
     nonce: walletInfo.nonce,
+    publicKey: walletInfo.publicKey,
     balances: {},
     positions: {},
     errors: [],

--- a/test/hub-distributor.test.ts
+++ b/test/hub-distributor.test.ts
@@ -10,6 +10,7 @@ vi.mock('ethers', async () => {
   const mockWallet = {
     address: '0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
     privateKey: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    publicKey: '0x04742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
   };
   
   return {
@@ -114,12 +115,14 @@ describe('HubDistributor', () => {
           wallet: {} as any,
           index: 0,
           nonce: 0,
+          publicKey: '0x04742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
         },
         {
           address: '0x842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9',
           wallet: {} as any,
           index: 1,
           nonce: 0,
+          publicKey: '0x04842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9',
         },
       ];
 
@@ -164,6 +167,7 @@ describe('HubDistributor', () => {
           wallet: {} as any,
           index: 0,
           nonce: 0,
+          publicKey: '0x04742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
         },
       ];
 
@@ -231,9 +235,9 @@ describe('HubDistributor', () => {
       
       // Créer des wallets de test
       const mockWallets: WalletInfo[] = [
-        { address: '0x1', wallet: {} as any, index: 0, nonce: 0 },
-        { address: '0x2', wallet: {} as any, index: 1, nonce: 0 },
-        { address: '0x3', wallet: {} as any, index: 2, nonce: 0 },
+        { address: '0x1', wallet: {} as any, index: 0, nonce: 0, publicKey: '0x041' },
+        { address: '0x2', wallet: {} as any, index: 1, nonce: 0, publicKey: '0x042' },
+        { address: '0x3', wallet: {} as any, index: 2, nonce: 0, publicKey: '0x043' },
       ];
 
       // Mock calculateRandomAmounts
@@ -293,8 +297,8 @@ describe('HubDistributor', () => {
   describe('distributeToken', () => {
     it('devrait distribuer un token vers plusieurs wallets', async () => {
       const mockWallets: WalletInfo[] = [
-        { address: '0x1', wallet: {} as any, index: 0, nonce: 0 },
-        { address: '0x2', wallet: {} as any, index: 1, nonce: 0 },
+        { address: '0x1', wallet: {} as any, index: 0, nonce: 0, publicKey: '0x041' },
+        { address: '0x2', wallet: {} as any, index: 1, nonce: 0, publicKey: '0x042' },
       ];
 
       const amounts = [10, 10];
@@ -317,8 +321,8 @@ describe('HubDistributor', () => {
 
     it('devrait gérer les erreurs de distribution', async () => {
       const mockWallets: WalletInfo[] = [
-        { address: '0x1', wallet: {} as any, index: 0, nonce: 0 },
-        { address: '0x2', wallet: {} as any, index: 1, nonce: 0 },
+        { address: '0x1', wallet: {} as any, index: 0, nonce: 0, publicKey: '0x041' },
+        { address: '0x2', wallet: {} as any, index: 1, nonce: 0, publicKey: '0x042' },
       ];
 
       const amounts = [10, 10];

--- a/test/integration/components.test.ts
+++ b/test/integration/components.test.ts
@@ -77,18 +77,20 @@ vi.mock('../../src/core/wallet-manager.js', () => ({
           provider: provider,
           getNonce: vi.fn().mockResolvedValue(0),
           sendTransaction: vi.fn().mockResolvedValue({ hash: `0x${walletCounter}tx`, wait: vi.fn().mockResolvedValue({ status: 1 }) }),
+          publicKey: `0x04${walletCounter.toString().padStart(128, '0')}`,
         };
-        
+
         const walletInfo = {
           address: mockWallet.address,
           wallet: mockWallet,
           index: index,
           nonce: 0,
+          publicKey: mockWallet.publicKey,
         };
-        
-        wallets.set(mockWallet.address, walletInfo);
+
+        wallets.set(mockWallet.address.toLowerCase(), walletInfo);
         walletCounter++;
-        
+
         return walletInfo;
       }),
       getWallets: vi.fn(() => Array.from(wallets.values())),
@@ -103,7 +105,8 @@ vi.mock('../../src/core/wallet-manager.js', () => ({
       }),
       getStats: vi.fn(() => ({
         totalWallets: wallets.size,
-        walletAddresses: Array.from(wallets.keys()),
+        addresses: Array.from(wallets.values()).map((info) => info.address),
+        publicKeys: Array.from(wallets.values()).map((info) => info.publicKey),
         nonceStats: Object.fromEntries(Array.from(wallets.entries()).map(([addr, info]) => [addr, info.nonce])),
       })),
     };
@@ -135,7 +138,8 @@ describe('Integration Tests - Components', () => {
       // Vérifier les statistiques
       const stats = walletManager.getStats();
       expect(stats.totalWallets).toBe(3);
-      expect(stats.walletAddresses).toHaveLength(3);
+      expect(stats.addresses).toHaveLength(3);
+      expect(stats.publicKeys).toHaveLength(3);
     });
 
     it('devrait gérer les nonces correctement', async () => {

--- a/test/multi-wallet-orchestrator-fixed.test.ts
+++ b/test/multi-wallet-orchestrator-fixed.test.ts
@@ -250,6 +250,7 @@ describe('MultiWalletOrchestrator', () => {
         wallet: {} as any,
         index: 0,
         nonce: 0,
+        publicKey: '0x04742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
       };
 
       mockOrchestratorService.run.mockResolvedValue({
@@ -277,8 +278,9 @@ describe('MultiWalletOrchestrator', () => {
     it('devrait retourner les statistiques des wallets', () => {
       const mockStats = {
         totalWallets: 2,
-        walletAddresses: ['0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8', '0x842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9'],
-        nonceStats: { '0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8': 0, '0x842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9': 0 },
+        addresses: ['0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8', '0x842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9'],
+        publicKeys: ['0x04742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8', '0x04842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9'],
+        nonceStats: { '0x742d35cc6634c0532925a3b8d1b2b3b4c5d6e7f8': 0, '0x842d35cc6634c0532925a3b8d1b2b3b4c5d6e7f9': 0 },
       };
 
       mockWalletManager.getStats.mockReturnValue(mockStats);

--- a/test/multi-wallet-orchestrator.test.ts
+++ b/test/multi-wallet-orchestrator.test.ts
@@ -250,6 +250,7 @@ describe('MultiWalletOrchestrator', () => {
         wallet: {} as any,
         index: 0,
         nonce: 0,
+        publicKey: '0x04742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
       };
 
       mockOrchestratorService.run.mockResolvedValue({
@@ -277,8 +278,9 @@ describe('MultiWalletOrchestrator', () => {
     it('devrait retourner les statistiques des wallets', () => {
       const mockStats = {
         totalWallets: 2,
-        walletAddresses: ['0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8', '0x842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9'],
-        nonceStats: { '0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8': 0, '0x842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9': 0 },
+        addresses: ['0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8', '0x842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9'],
+        publicKeys: ['0x04742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8', '0x04842d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F9'],
+        nonceStats: { '0x742d35cc6634c0532925a3b8d1b2b3b4c5d6e7f8': 0, '0x842d35cc6634c0532925a3b8d1b2b3b4c5d6e7f9': 0 },
       };
 
       mockWalletManager.getStats.mockReturnValue(mockStats);

--- a/test/wallet-manager.test.ts
+++ b/test/wallet-manager.test.ts
@@ -8,6 +8,12 @@ vi.mock('ethers', async (importOriginal) => {
   const mockWallet = {
     address: '0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
     privateKey: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    publicKey: '0x04bfcab58fbd8c6f5f5d3b1782e46b408e5f1e7d512975a9f03d3bd6e10c7a8f17e5b6b7bde7f73c62f0bca6ecb3efa1b9bd8e5dcd7f2571c2cb2bfa7b4b5b6c',
+  };
+
+  const mockHdNode = {
+    privateKey: mockWallet.privateKey,
+    publicKey: mockWallet.publicKey,
   };
   
   // Mock du constructeur Wallet
@@ -23,6 +29,9 @@ vi.mock('ethers', async (importOriginal) => {
   return {
     ...actual,
     Wallet: MockWallet,
+    HDNodeWallet: {
+      fromPhrase: vi.fn(() => mockHdNode),
+    },
   };
 });
 
@@ -48,6 +57,7 @@ vi.mock('../src/core/rpc.js', () => ({
 const mockWallet = {
   address: '0x742d35Cc6634C0532925a3b8D1B2b3b4C5D6E7F8',
   privateKey: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  publicKey: '0x04bfcab58fbd8c6f5f5d3b1782e46b408e5f1e7d512975a9f03d3bd6e10c7a8f17e5b6b7bde7f73c62f0bca6ecb3efa1b9bd8e5dcd7f2571c2cb2bfa7b4b5b6c',
 };
 
 const mockProvider = {
@@ -77,6 +87,7 @@ describe('WalletManager', () => {
       expect(result.address.startsWith('0x')).toBe(true);
       expect(result.index).toBe(0);
       expect(walletManager.hasWallet(result.address)).toBe(true);
+      expect(result.publicKey).toBe(mockWallet.publicKey);
     });
 
     it('devrait créer des wallets avec des index différents', () => {
@@ -107,6 +118,7 @@ describe('WalletManager', () => {
       expect(result.address.startsWith('0x')).toBe(true);
       expect(result.index).toBe(5);
       expect(walletManager.hasWallet(result.address)).toBe(true);
+      expect(result.publicKey).toBe(mockWallet.publicKey);
     });
   });
 
@@ -210,8 +222,9 @@ describe('WalletManager', () => {
       const stats = walletManager.getStats();
 
       expect(stats.totalWallets).toBe(1);
-      expect(stats.walletAddresses).toHaveLength(1);
-      expect(stats.nonceStats).toHaveProperty(walletResult.address);
+      expect(stats.addresses).toHaveLength(1);
+      expect(stats.publicKeys).toHaveLength(1);
+      expect(stats.nonceStats).toHaveProperty(walletResult.address.toLowerCase());
     });
   });
 
@@ -232,6 +245,13 @@ describe('WalletManager', () => {
       const mnemonic = WalletManager.generateMnemonic();
       expect(typeof mnemonic).toBe('string');
       expect(mnemonic.split(' ')).toHaveLength(12);
+    });
+  });
+
+  describe('getPublicKeyFromMnemonic', () => {
+    it('devrait retourner la clé publique pour un index donné', () => {
+      const publicKey = walletManager.getPublicKeyFromMnemonic(testMnemonic, 0);
+      expect(publicKey).toBe(mockWallet.publicKey);
     });
   });
 });


### PR DESCRIPTION
## Summary
- ensure wallets derived from mnemonics use the correct BIP-44 path, normalize address keys, and expose public keys/derivation metadata
- extend wallet manager stats helpers and CLI status output to surface wallet public keys and updated addressing logic
- refresh unit and integration test mocks to cover the new wallet metadata and derivation helpers

## Testing
- Attempted `node --no-warnings node_modules/vitest/vitest.mjs run test/wallet-manager.test.ts test/wallet-manager-simple.test.ts test/multi-wallet-orchestrator.test.ts test/multi-wallet-orchestrator-fixed.test.ts test/hub-distributor.test.ts test/integration/components.test.ts` *(fails: existing suite depends on extensive environment setup and CLI build artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68d39c7721688322b93f39f9a2883ff0